### PR TITLE
:bug:: Allow empty node-tree on application

### DIFF
--- a/src/utils/update_application_graph.ts
+++ b/src/utils/update_application_graph.ts
@@ -58,7 +58,7 @@ export function updateApplicationSubResources(
   appId: string | undefined,
   resourceTree: ArgoResourceTree
 ): void {
-  for (const node of resourceTree.nodes) {
+  for (const node of resourceTree?.nodes ?? []) {
     // We only care about Application and ApplicationSet resources
     if (node.group !== 'argoproj.io' || (node.kind !== 'Application' && node.kind !== 'ApplicationSet')) {
       continue;


### PR DESCRIPTION
This pull request includes a small but important improvement in the `updateApplicationSubResources` function to handle potential undefined values in the `resourceTree` parameter.

* [`src/utils/update_application_graph.ts`](diffhunk://#diff-a44d6e8b8fa3f21d6c1dc6a5b88ffee1fc3eccfe769f5b9e82d4e4f98bbf5a23L61-R61): Updated the loop to safely handle cases where `resourceTree` might be undefined or its `nodes` property is missing by using the nullish coalescing operator (`??`).

Could fix #67 