### PR TITLE
:sparkles: Implement Quick Actions for Application Nodes (Sync & Refresh)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -21,6 +21,8 @@ const config: StorybookConfig = {
     autodocs: true,
   },
 
+  staticDirs: ['../src/mocks/storybook-public'],
+
   typescript: {
     reactDocgen: 'react-docgen',
   },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,3 +1,5 @@
+import { initialize as mswInitialize, mswLoader } from 'msw-storybook-addon';
+
 import type { Preview, StoryFn } from '@storybook/react';
 
 import React from 'react';
@@ -18,6 +20,8 @@ const withColorScheme = (Story: StoryFn, { parameters }: any) => {
   );
 };
 
+mswInitialize();
+
 const preview: Preview = {
   parameters: {
     controls: {
@@ -35,6 +39,7 @@ const preview: Preview = {
     },
   },
   decorators: [withColorScheme],
+  loaders: [mswLoader],
 };
 
 export default preview;

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "jest": "^30.0.0",
     "jest-environment-jsdom": "^30.0.0",
     "jest-junit": "^16.0.0",
+    "msw": "^2.10.4",
+    "msw-storybook-addon": "^2.0.5",
     "playwright": "^1.52.0",
     "raw-loader": "^4.0.2",
     "sass": "^1.89.0",
@@ -91,5 +93,11 @@
     "webpack": "^5.99.8",
     "webpack-bundle-analyzer": "^4.10.2",
     "webpack-cli": "^6.0.1"
+  },
+  "msw": {
+    "workerDirectory": [
+      "dist",
+      "src/mocks/storybook-public"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,7 +65,7 @@ importers:
         version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)
       '@storybook/react-webpack5':
         specifier: ^8.6.14
-        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(@swc/core@1.11.31)(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)
+        version: 8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(@swc/core@1.11.29)(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)
       '@storybook/test':
         specifier: ^8.6.14
         version: 8.6.14(storybook@8.6.14)
@@ -117,6 +117,12 @@ importers:
       jest-junit:
         specifier: ^16.0.0
         version: 16.0.0
+      msw:
+        specifier: ^2.10.4
+        version: 2.10.4(@types/node@24.0.10)(typescript@5.8.3)
+      msw-storybook-addon:
+        specifier: ^2.0.5
+        version: 2.0.5(msw@2.10.4(@types/node@24.0.10)(typescript@5.8.3))
       playwright:
         specifier: ^1.52.0
         version: 1.54.1
@@ -149,7 +155,7 @@ importers:
         version: 5.8.3
       webpack:
         specifier: ^5.99.8
-        version: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+        version: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-bundle-analyzer:
         specifier: ^4.10.2
         version: 4.10.2
@@ -819,6 +825,15 @@ packages:
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
+  '@bundled-es-modules/cookie@2.0.1':
+    resolution: {integrity: sha512-8o+5fRPLNbjbdGRRmJj3h6Hh1AQJf2dk3qQ/5ZFb+PXkRNiSoMGGUKlsgLfrxneb72axVJyIYji64E2+nNfYyw==}
+
+  '@bundled-es-modules/statuses@1.0.1':
+    resolution: {integrity: sha512-yn7BklA5acgcBr+7w064fGV+SGIFySjCKpqjcWgBAIfrAkY+4GQTJJHQMeT3V/sgz23VTEVV8TtOmkvJAhFVfg==}
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    resolution: {integrity: sha512-dvMHbL464C0zI+Yqxbz6kZ5TOEp7GLW+pry/RWndAR8MJQAXZ2rPmIs8tziTZjeIyhSNZgZbCePtfSbdWqStJw==}
+
   '@chromatic-com/storybook@3.2.7':
     resolution: {integrity: sha512-fCGhk4cd3VA8RNg55MZL5CScdHqljsQcL9g6Ss7YuobHpSo9yytEWNdgMd5QxAHSPBlLGFHjnSmliM3G/BeBqw==}
     engines: {node: '>=16.0.0', yarn: '>=1.22.18'}
@@ -1095,6 +1110,37 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@inquirer/confirm@5.1.13':
+    resolution: {integrity: sha512-EkCtvp67ICIVVzjsquUiVSd+V5HRGOGQfsqA4E4vMWhYnB7InUL0pa0TIWt1i+OfP16Gkds8CdIu6yGZwOM1Yw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.1.14':
+    resolution: {integrity: sha512-Ma+ZpOJPewtIYl6HZHZckeX1STvDnHTCB2GVINNUlSEn2Am6LddWwfPkIGY0IUFVjUUrr/93XlBwTK6mfLjf0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.12':
+    resolution: {integrity: sha512-MJttijd8rMFcKJC8NYmprWr6hD3r9Gd9qUC0XwPNwoEPWSMVJwA2MlXxF+nhZZNMY+HXsWa+o7KY2emWYIn0jQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.7':
+    resolution: {integrity: sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -1329,6 +1375,10 @@ packages:
       '@types/react': '>=16'
       react: '>=16'
 
+  '@mswjs/interceptors@0.39.3':
+    resolution: {integrity: sha512-9bw/wBL7pblsnOCIqvn1788S9o4h+cC5HWXg0Xhh0dOzsZ53IyfmBM+FYqpDDPbm0xjCqEqvCITloF3Dm4TXRQ==}
+    engines: {node: '>=18'}
+
   '@napi-rs/wasm-runtime@0.2.11':
     resolution: {integrity: sha512-9DPkXtvHydrcOsopiYpUgPHpmj0HWZKMUnL2dZqpvC42lsratuBG06V5ipyno0fUek5VlFsNQ+AcFATSrJXgMA==}
 
@@ -1343,6 +1393,15 @@ packages:
   '@nodelib/fs.walk@1.2.8':
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@parcel/watcher-android-arm64@2.5.1':
     resolution: {integrity: sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==}
@@ -1873,6 +1932,9 @@ packages:
   '@types/babel__traverse@7.20.7':
     resolution: {integrity: sha512-dkO5fhS7+/oos4ciWxyEyjWe48zmG6wbCheo/G2ZnHx4fs3EU6YC6UM8rk56gAjNJ9P3MTH2jo5jb92/K6wbng==}
 
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
   '@types/d3-color@3.1.3':
     resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
 
@@ -1964,6 +2026,9 @@ packages:
 
   '@types/stack-utils@2.0.3':
     resolution: {integrity: sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==}
+
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
@@ -2629,6 +2694,10 @@ packages:
     resolution: {integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==}
     engines: {node: '>=6'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
 
@@ -2699,6 +2768,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   core-js-compat@3.44.0:
     resolution: {integrity: sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==}
@@ -3365,6 +3438,10 @@ packages:
     peerDependencies:
       graphology-types: '>=0.24.0'
 
+  graphql@16.11.0:
+    resolution: {integrity: sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   gzip-size@6.0.0:
     resolution: {integrity: sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==}
     engines: {node: '>=10'}
@@ -3402,6 +3479,9 @@ packages:
   he@1.2.0:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   homedir-polyfill@1.0.3:
     resolution: {integrity: sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==}
@@ -3547,6 +3627,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number@7.0.0:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
@@ -4178,6 +4261,25 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw-storybook-addon@2.0.5:
+    resolution: {integrity: sha512-uum2gtprDBoUb8GV/rPMwPytHmB8+AUr25BQUY0MpjYey5/ujaew2Edt+4oHiXpLTd0ThyMqmEvGy/sRpDV4lg==}
+    peerDependencies:
+      msw: ^2.0.0
+
+  msw@2.10.4:
+    resolution: {integrity: sha512-6R1or/qyele7q3RyPwNuvc0IxO8L8/Aim6Sz5ncXEgcWUNxSKE+udriTOWHtpMwmfkLYlacA2y7TIx4cL5lgHA==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4262,6 +4364,9 @@ packages:
     resolution: {integrity: sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==}
     engines: {node: '>=0.10.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   p-limit@2.3.0:
     resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
     engines: {node: '>=6'}
@@ -4339,6 +4444,9 @@ packages:
   path-scurry@1.11.1:
     resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
     engines: {node: '>=16 || 14 >=14.18'}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -4462,6 +4570,9 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
+
   punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
 
@@ -4478,6 +4589,9 @@ packages:
   qs@6.14.0:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -4591,6 +4705,9 @@ packages:
 
   require-main-filename@2.0.0:
     resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-cwd@3.0.0:
     resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
@@ -4793,6 +4910,10 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   storybook-addon-deep-controls@0.9.4:
     resolution: {integrity: sha512-0iq9r9VyfifsapQT44sIQDALtA/jIiG1lIW4itR52i2qXCHEVEgvPMtZ4ZcMbajxZcajwlYsWxiQBeEgvnA6lQ==}
     peerDependencies:
@@ -4808,6 +4929,9 @@ packages:
     peerDependenciesMeta:
       prettier:
         optional: true
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
 
   string-length@4.0.2:
     resolution: {integrity: sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==}
@@ -4963,6 +5087,10 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tough-cookie@5.1.2:
     resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
     engines: {node: '>=16'}
@@ -5083,6 +5211,10 @@ packages:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -5102,6 +5234,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
@@ -5353,6 +5488,10 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.2:
+    resolution: {integrity: sha512-cYVsTjKl8b+FrnidjibDWskAv7UKOfcwaVZdp/it9n1s9fU3IkgDbhdIRKCW4JDsAlECJY0ytoVPT3sK6kideA==}
+    engines: {node: '>=18'}
 
   zustand@4.5.7:
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
@@ -6333,6 +6472,19 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@bundled-es-modules/cookie@2.0.1':
+    dependencies:
+      cookie: 0.7.2
+
+  '@bundled-es-modules/statuses@1.0.1':
+    dependencies:
+      statuses: 2.0.2
+
+  '@bundled-es-modules/tough-cookie@0.1.6':
+    dependencies:
+      '@types/tough-cookie': 4.0.5
+      tough-cookie: 4.1.4
+
   '@chromatic-com/storybook@3.2.7(react@18.3.1)(storybook@8.6.14)':
     dependencies:
       chromatic: 11.29.0
@@ -6533,6 +6685,32 @@ snapshots:
   '@humanwhocodes/retry@0.3.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@inquirer/confirm@5.1.13(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/core': 10.1.14(@types/node@24.0.10)
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/core@10.1.14(@types/node@24.0.10)':
+    dependencies:
+      '@inquirer/figures': 1.0.12
+      '@inquirer/type': 3.0.7(@types/node@24.0.10)
+      ansi-escapes: 4.3.2
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.2
+    optionalDependencies:
+      '@types/node': 24.0.10
+
+  '@inquirer/figures@1.0.12': {}
+
+  '@inquirer/type@3.0.7(@types/node@24.0.10)':
+    optionalDependencies:
+      '@types/node': 24.0.10
 
   '@isaacs/cliui@8.0.2':
     dependencies:
@@ -6976,6 +7154,15 @@ snapshots:
       '@types/react': 18.3.23
       react: 18.3.1
 
+  '@mswjs/interceptors@0.39.3':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
+
   '@napi-rs/wasm-runtime@0.2.11':
     dependencies:
       '@emnapi/core': 1.4.4
@@ -6994,6 +7181,15 @@ snapshots:
     dependencies:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@parcel/watcher-android-arm64@2.5.1':
     optional: true
@@ -7193,7 +7389,7 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-webpack5@8.6.14(@swc/core@1.11.31)(esbuild@0.25.5)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)':
+  '@storybook/builder-webpack5@8.6.14(@swc/core@1.11.29)(esbuild@0.25.5)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)':
     dependencies:
       '@storybook/core-webpack': 8.6.14(storybook@8.6.14)
       '@types/semver': 7.7.0
@@ -7211,12 +7407,12 @@ snapshots:
       semver: 7.7.2
       storybook: 8.6.14
       style-loader: 3.3.4(webpack@5.100.2)
-      terser-webpack-plugin: 5.3.14(@swc/core@1.11.31)(esbuild@0.25.5)(webpack@5.100.2)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.11.29)(esbuild@0.25.5)(webpack@5.100.2)
       ts-dedent: 2.2.0
       url: 0.11.4
       util: 0.12.5
       util-deprecate: 1.0.2
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-dev-middleware: 6.1.3(webpack@5.100.2)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
@@ -7283,7 +7479,7 @@ snapshots:
     dependencies:
       storybook: 8.6.14
 
-  '@storybook/preset-react-webpack@8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(@swc/core@1.11.31)(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)':
+  '@storybook/preset-react-webpack@8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(@swc/core@1.11.29)(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)':
     dependencies:
       '@storybook/core-webpack': 8.6.14(storybook@8.6.14)
       '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)
@@ -7298,7 +7494,7 @@ snapshots:
       semver: 7.7.2
       storybook: 8.6.14
       tsconfig-paths: 4.2.0
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -7323,7 +7519,7 @@ snapshots:
       react-docgen-typescript: 2.2.2(typescript@5.8.3)
       tslib: 2.8.1
       typescript: 5.8.3
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -7333,10 +7529,10 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       storybook: 8.6.14
 
-  '@storybook/react-webpack5@8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(@swc/core@1.11.31)(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)':
+  '@storybook/react-webpack5@8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(@swc/core@1.11.29)(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)':
     dependencies:
-      '@storybook/builder-webpack5': 8.6.14(@swc/core@1.11.31)(esbuild@0.25.5)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)
-      '@storybook/preset-react-webpack': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(@swc/core@1.11.31)(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)
+      '@storybook/builder-webpack5': 8.6.14(@swc/core@1.11.29)(esbuild@0.25.5)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)
+      '@storybook/preset-react-webpack': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(@swc/core@1.11.29)(esbuild@0.25.5)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)(webpack-cli@6.0.1)
       '@storybook/react': 8.6.14(@storybook/test@8.6.14(storybook@8.6.14))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.6.14)(typescript@5.8.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -7598,6 +7794,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.0
 
+  '@types/cookie@0.6.0': {}
+
   '@types/d3-color@3.1.3': {}
 
   '@types/d3-drag@3.0.7':
@@ -7698,6 +7896,8 @@ snapshots:
   '@types/semver@7.7.0': {}
 
   '@types/stack-utils@2.0.3': {}
+
+  '@types/statuses@2.0.6': {}
 
   '@types/tough-cookie@4.0.5': {}
 
@@ -7936,17 +8136,17 @@ snapshots:
 
   '@webpack-cli/configtest@3.0.1(webpack-cli@6.0.1)(webpack@5.100.2)':
     dependencies:
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.100.2)
 
   '@webpack-cli/info@3.0.1(webpack-cli@6.0.1)(webpack@5.100.2)':
     dependencies:
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.100.2)
 
   '@webpack-cli/serve@3.0.1(webpack-cli@6.0.1)(webpack@5.100.2)':
     dependencies:
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-cli: 6.0.1(webpack-bundle-analyzer@4.10.2)(webpack@5.100.2)
 
   '@xtuc/ieee754@1.2.0': {}
@@ -8441,6 +8641,8 @@ snapshots:
 
   clean-stack@2.2.0: {}
 
+  cli-width@4.1.0: {}
+
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -8501,6 +8703,8 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
+  cookie@0.7.2: {}
+
   core-js-compat@3.44.0:
     dependencies:
       browserslist: 4.25.1
@@ -8547,7 +8751,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   css-loader@7.1.2(webpack@5.100.2):
     dependencies:
@@ -8560,7 +8764,7 @@ snapshots:
       postcss-value-parser: 4.2.0
       semver: 7.7.2
     optionalDependencies:
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   css-select@4.3.0:
     dependencies:
@@ -8803,7 +9007,7 @@ snapshots:
       esbuild: 0.25.5
       get-tsconfig: 4.10.1
       loader-utils: 2.0.4
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-sources: 1.4.3
 
   esbuild-register@3.6.0(esbuild@0.25.5):
@@ -9108,7 +9312,7 @@ snapshots:
       semver: 7.7.2
       tapable: 2.2.2
       typescript: 5.8.3
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   form-data@4.0.3:
     dependencies:
@@ -9225,6 +9429,8 @@ snapshots:
       events: 3.3.0
       graphology-types: 0.24.8
 
+  graphql@16.11.0: {}
+
   gzip-size@6.0.0:
     dependencies:
       duplexer: 0.1.2
@@ -9256,6 +9462,8 @@ snapshots:
 
   he@1.2.0: {}
 
+  headers-polyfill@4.0.3: {}
+
   homedir-polyfill@1.0.3:
     dependencies:
       parse-passwd: 1.0.0
@@ -9286,7 +9494,7 @@ snapshots:
       pretty-error: 4.0.0
       tapable: 2.2.2
     optionalDependencies:
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   htmlparser2@3.10.1:
     dependencies:
@@ -9396,6 +9604,8 @@ snapshots:
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
+
+  is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
 
@@ -10457,6 +10667,38 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw-storybook-addon@2.0.5(msw@2.10.4(@types/node@24.0.10)(typescript@5.8.3)):
+    dependencies:
+      is-node-process: 1.2.0
+      msw: 2.10.4(@types/node@24.0.10)(typescript@5.8.3)
+
+  msw@2.10.4(@types/node@24.0.10)(typescript@5.8.3):
+    dependencies:
+      '@bundled-es-modules/cookie': 2.0.1
+      '@bundled-es-modules/statuses': 1.0.1
+      '@bundled-es-modules/tough-cookie': 0.1.6
+      '@inquirer/confirm': 5.1.13(@types/node@24.0.10)
+      '@mswjs/interceptors': 0.39.3
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/until': 2.1.0
+      '@types/cookie': 0.6.0
+      '@types/statuses': 2.0.6
+      graphql: 16.11.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      strict-event-emitter: 0.5.1
+      type-fest: 4.41.0
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@2.0.0: {}
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.0: {}
@@ -10558,6 +10800,8 @@ snapshots:
 
   os-homedir@1.0.2: {}
 
+  outvariant@1.4.3: {}
+
   p-limit@2.3.0:
     dependencies:
       p-try: 2.2.0
@@ -10632,6 +10876,8 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
       minipass: 7.1.2
+
+  path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 
@@ -10745,6 +10991,10 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode@1.4.1: {}
 
   punycode@2.3.1: {}
@@ -10756,6 +11006,8 @@ snapshots:
   qs@6.14.0:
     dependencies:
       side-channel: 1.1.0
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -10769,7 +11021,7 @@ snapshots:
     dependencies:
       loader-utils: 2.0.4
       schema-utils: 3.3.0
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   react-confetti@6.4.0(react@18.3.1):
     dependencies:
@@ -10881,6 +11133,8 @@ snapshots:
 
   require-main-filename@2.0.0: {}
 
+  requires-port@1.0.0: {}
+
   resolve-cwd@3.0.0:
     dependencies:
       resolve-from: 5.0.0
@@ -10935,7 +11189,7 @@ snapshots:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.89.2
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   sass@1.89.2:
     dependencies:
@@ -11081,6 +11335,8 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  statuses@2.0.2: {}
+
   storybook-addon-deep-controls@0.9.4(@storybook/addon-controls@8.6.14(storybook@8.6.14))(@storybook/types@8.6.14(storybook@8.6.14))(storybook@8.6.14):
     dependencies:
       '@storybook/addon-controls': 8.6.14(storybook@8.6.14)
@@ -11094,6 +11350,8 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  strict-event-emitter@0.5.1: {}
 
   string-length@4.0.2:
     dependencies:
@@ -11147,11 +11405,11 @@ snapshots:
 
   style-loader@3.3.4(webpack@5.100.2):
     dependencies:
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   style-loader@4.0.0(webpack@5.100.2):
     dependencies:
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   supports-color@5.5.0:
     dependencies:
@@ -11171,7 +11429,7 @@ snapshots:
     dependencies:
       '@swc/core': 1.11.29
       '@swc/counter': 0.1.3
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   symbol-tree@3.2.4: {}
 
@@ -11181,16 +11439,16 @@ snapshots:
 
   tapable@2.2.2: {}
 
-  terser-webpack-plugin@5.3.14(@swc/core@1.11.31)(esbuild@0.25.5)(webpack@5.100.2):
+  terser-webpack-plugin@5.3.14(@swc/core@1.11.29)(esbuild@0.25.5)(webpack@5.100.2):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.29
       jest-worker: 27.5.1
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.43.1
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
     optionalDependencies:
-      '@swc/core': 1.11.31
+      '@swc/core': 1.11.29
       esbuild: 0.25.5
 
   terser@5.43.1:
@@ -11227,6 +11485,13 @@ snapshots:
       is-number: 7.0.0
 
   totalist@3.0.1: {}
+
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
 
   tough-cookie@5.1.2:
     dependencies:
@@ -11273,7 +11538,7 @@ snapshots:
       semver: 7.7.2
       source-map: 0.7.4
       typescript: 5.8.3
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   tsconfig-paths@4.2.0:
     dependencies:
@@ -11320,6 +11585,8 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.1.0: {}
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   unplugin@1.16.1:
@@ -11360,6 +11627,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   url@0.11.4:
     dependencies:
@@ -11457,7 +11729,7 @@ snapshots:
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
       webpack-merge: 6.0.1
     optionalDependencies:
       webpack-bundle-analyzer: 4.10.2
@@ -11470,7 +11742,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.2
     optionalDependencies:
-      webpack: 5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1)
+      webpack: 5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1)
 
   webpack-hot-middleware@2.26.1:
     dependencies:
@@ -11493,7 +11765,7 @@ snapshots:
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.100.2(@swc/core@1.11.31)(esbuild@0.25.5)(webpack-cli@6.0.1):
+  webpack@5.100.2(@swc/core@1.11.29)(esbuild@0.25.5)(webpack-cli@6.0.1):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8
@@ -11517,7 +11789,7 @@ snapshots:
       neo-async: 2.6.2
       schema-utils: 4.3.2
       tapable: 2.2.2
-      terser-webpack-plugin: 5.3.14(@swc/core@1.11.31)(esbuild@0.25.5)(webpack@5.100.2)
+      terser-webpack-plugin: 5.3.14(@swc/core@1.11.29)(esbuild@0.25.5)(webpack@5.100.2)
       watchpack: 2.4.4
       webpack-sources: 3.3.3
     optionalDependencies:
@@ -11651,6 +11923,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.2: {}
 
   zustand@4.5.7(@types/react@18.3.23)(react@18.3.1):
     dependencies:

--- a/src/components/application-map/ApplicationMap.stories.tsx
+++ b/src/components/application-map/ApplicationMap.stories.tsx
@@ -6,6 +6,7 @@ import { ReactFlowProvider } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import React from 'react';
 
+import { allowCanI, denyCanI } from '../../mocks/handlers';
 import '../../styles/index.scss';
 import { HealthStatus, RankDirection, isApplication } from '../../types';
 import { allStatusScenario, denseScenario as complexTopology } from '../.storybook/scenarii';
@@ -36,6 +37,11 @@ export const Default: Story = {
     onPaneClick: action('onPaneClick'),
     onApplicationClick: action('onApplicationClick'),
   },
+  parameters: {
+    msw: {
+      handlers: [allowCanI('applications', 'sync'), denyCanI('applications', 'get')],
+    },
+  },
 };
 
 export const DefaultDark: Story = {
@@ -53,14 +59,23 @@ export const ComplexTopology: Story = {
     onPaneClick: action('onPaneClick'),
     onApplicationClick: action('onApplicationClick'),
   },
+  parameters: {
+    msw: {
+      handlers: [allowCanI('applications', 'sync'), denyCanI('applications', 'get')],
+    },
+  },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
     const root_app_1 = await canvas.findByTestId('rf__node-Application/default/root-app1');
-    expect(root_app_1.children[0]).toHaveClass('application-resource-tree__node--default');
+    expect(root_app_1.children[0]).toHaveClass(
+      'application-resource-tree__node argocd-application-map__node argocd-application-map__node--default'
+    );
 
     const root_app_2 = await canvas.findByTestId('rf__node-Application/default/root-app2');
-    expect(root_app_2.children[0]).toHaveClass('application-resource-tree__node--default');
+    expect(root_app_2.children[0]).toHaveClass(
+      'application-resource-tree__node argocd-application-map__node argocd-application-map__node--default'
+    );
   },
 };
 
@@ -85,10 +100,14 @@ export const ComplexTopologyWithSelection: Story = {
     const canvas = within(canvasElement);
 
     const root_app_1 = await canvas.findByTestId('rf__node-Application/default/root-app1');
-    expect(root_app_1.children[0]).toHaveClass('application-resource-tree__node--unselected');
+    expect(root_app_1.children[0]).toHaveClass(
+      'application-resource-tree__node argocd-application-map__node argocd-application-map__node--unselected'
+    );
 
     const root_app_2 = await canvas.findByTestId('rf__node-Application/default/root-app2');
-    expect(root_app_2.children[0]).toHaveClass('application-resource-tree__node--selected');
+    expect(root_app_2.children[0]).toHaveClass(
+      'application-resource-tree__node argocd-application-map__node argocd-application-map__node--selected'
+    );
   },
 };
 

--- a/src/components/application-map/node/ApplicationMapNode.stories.tsx
+++ b/src/components/application-map/node/ApplicationMapNode.stories.tsx
@@ -6,6 +6,7 @@ import { ReactFlowProvider } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
 import React from 'react';
 
+import { allowCanI } from '../../../mocks/handlers';
 import '../../../styles/index.scss';
 import { HealthStatus, SyncStatus } from '../../../types/application';
 import { NODE_HEIGHT, NODE_WIDTH } from '../ApplicationMap';
@@ -83,6 +84,9 @@ export const Application: Story = {
       ],
     },
     deepControls: { enabled: true },
+    msw: {
+      handlers: [allowCanI('applications', 'sync'), allowCanI('applications', 'get')],
+    },
   },
   args: applicationNodeProps,
   argTypes: {
@@ -180,7 +184,7 @@ export const ApplicationSet: Story = {
     // Check if the ApplicationSet icon is rendered
     const icon = await canvas.findByLabelText('ApplicationSet icon');
     expect(icon).not.toBeNull();
-    expect(icon).toHaveClass('as-icon');
+    expect(icon).toHaveClass('argocd-application-map__node-kind-icon__as-icon');
 
     // Check if the node kind text is rendered
     const nodeKind = await canvas.findByText('applicationset');

--- a/src/components/application-map/node/QuickActionButton.tsx
+++ b/src/components/application-map/node/QuickActionButton.tsx
@@ -1,0 +1,53 @@
+import React, { useCallback } from 'react';
+
+type QuickActionButtonProps = {
+  isUnlocked: boolean;
+  icon: string;
+  title: string;
+  onClick: () => Promise<{ success: true } | { success: false; error: string }>;
+};
+
+const QuickActionButton: React.FC<QuickActionButtonProps> = ({ isUnlocked, icon, title, onClick }) => {
+  if (!isUnlocked) {
+    return (
+      <button
+        className="argocd-application-map__node-quick-actions__button"
+        title={`${title} (not allowed for your user)`}
+        disabled
+      >
+        <i className={`fa fa-lock`}></i>
+      </button>
+    );
+  }
+
+  const [status, setStatus] = React.useState<'idle' | 'executing' | 'succeeded' | 'failed'>('idle');
+  const onClickHandler = useCallback(
+    async (event: React.MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+
+      setStatus('executing');
+      const result = await onClick();
+
+      if (result.success === true) {
+        setStatus('succeeded');
+        console.log(`${title} action completed successfully.`);
+      } else {
+        setStatus('failed');
+        console.error(`${title} action failed:`, result.error);
+      }
+    },
+    [onClick, title]
+  );
+
+  return (
+    <button
+      className={`argocd-application-map__node-quick-actions__button ${status}`}
+      onClick={onClickHandler}
+      title={title}
+    >
+      <i className={`fa ${icon}`}></i>
+    </button>
+  );
+};
+
+export default QuickActionButton;

--- a/src/hooks/__tests__/useCanI.test.ts
+++ b/src/hooks/__tests__/useCanI.test.ts
@@ -1,0 +1,80 @@
+import { renderHook, waitFor } from '@testing-library/react';
+
+import * as services from '../../services';
+import { useCanI } from '../useCanI';
+
+// Mock the services
+jest.mock('../../services', () => ({
+  services: {
+    account: {
+      canI: jest.fn(),
+    },
+  },
+}));
+
+const mockCanI = services.services.account.canI as jest.Mock;
+
+describe('usePermissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should check permission successfully', async () => {
+    mockCanI.mockResolvedValueOnce(true);
+    const { result } = renderHook(() => useCanI('applications', 'sync', 'namespace/app'));
+
+    await waitFor(() => {
+      expect(result.current.isAllowed).not.toBeNull();
+    });
+
+    expect(result.current.isAllowed).toBe(true);
+    expect(result.current.error).toBeNull();
+
+    expect(mockCanI).toHaveBeenCalledWith('applications', 'sync', 'namespace/app');
+  });
+
+  it('should handle permission check errors', async () => {
+    const error = new Error('Permission check failed');
+    mockCanI.mockRejectedValue(error);
+
+    const { result } = renderHook(() => useCanI('applications', 'sync', 'namespace/app'));
+
+    await waitFor(() => {
+      expect(result.current.isAllowed).not.toBeNull();
+    });
+
+    expect(result.current.isAllowed).toBe(false);
+    expect(result.current.error).toBe('Permission check failed');
+  });
+
+  it('should update permissions when dependencies change', async () => {
+    mockCanI
+      .mockResolvedValueOnce(true) // namespace1/app1
+      .mockResolvedValueOnce(false); // namespace2/app2
+
+    const { result, rerender } = renderHook(
+      ({ namespace, app }) => useCanI('applications', 'sync', `${namespace}/${app}`),
+      {
+        initialProps: { namespace: 'namespace1', app: 'app1' },
+      }
+    );
+
+    await waitFor(() => {
+      expect(result.current.isAllowed).not.toBeNull();
+    });
+
+    expect(result.current.isAllowed).toBe(true);
+
+    // Change props
+    rerender({ namespace: 'namespace2', app: 'app2' });
+
+    await waitFor(() => {
+      expect(result.current.isAllowed).not.toBeNull();
+    });
+
+    expect(result.current.isAllowed).toBe(false);
+
+    expect(mockCanI).toHaveBeenCalledWith('applications', 'sync', 'namespace1/app1');
+    expect(mockCanI).toHaveBeenCalledWith('applications', 'sync', 'namespace2/app2');
+  });
+});

--- a/src/hooks/useCanI.ts
+++ b/src/hooks/useCanI.ts
@@ -1,0 +1,38 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { services } from '../services';
+
+/**
+ * Hook for checking user permissions for quick actions
+ * @param resource - The resource type (e.g., 'applications')
+ * @param action - The action to perform (e.g., 'sync', 'get')
+ * @param subresource - The specific resource (e.g., 'project/app-name')
+ * @returns Permissions state and refresh function
+ */
+export function useCanI(resource: string, action: string, subresource: string) {
+  const [permission, setPermissions] = useState<boolean | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const checkPermissions = useCallback(async () => {
+    if (!resource || !action || !subresource) {
+      setPermissions(false);
+      return;
+    }
+    setError(null);
+
+    try {
+      setPermissions(await services.account.canI(resource, action, subresource));
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Failed to check permissions';
+      setPermissions(false);
+      setError(errorMessage);
+      console.error('Permission check error:', err);
+    }
+  }, [resource, action, subresource]);
+
+  useEffect(() => {
+    checkPermissions();
+  }, [checkPermissions]);
+
+  return { isAllowed: permission, error };
+}

--- a/src/mocks/handlers/index.ts
+++ b/src/mocks/handlers/index.ts
@@ -1,0 +1,1 @@
+export { allowCanI, denyCanI } from './mockedCanI';

--- a/src/mocks/handlers/mockedCanI.ts
+++ b/src/mocks/handlers/mockedCanI.ts
@@ -1,0 +1,11 @@
+import { HttpResponse, http } from 'msw';
+
+export const allowCanI = (resource: string, action: string, subresource: string = '*') =>
+  http.get(`/api/v1/account/can-i/${resource}/${action}/${subresource}`, () => {
+    return HttpResponse.json({ value: 'yes' });
+  });
+
+export const denyCanI = (resource: string, action: string, subresource: string = '*') =>
+  http.get(`/api/v1/account/can-i/${resource}/${action}/${subresource}`, () => {
+    return HttpResponse.json({ value: 'no' });
+  });

--- a/src/mocks/storybook-public/mockServiceWorker.js
+++ b/src/mocks/storybook-public/mockServiceWorker.js
@@ -1,0 +1,336 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.10.4';
+const INTEGRITY_CHECKSUM = 'f5825c521429caf22a4dd13b66e243af';
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse');
+const activeClientIds = new Set();
+
+addEventListener('install', function () {
+  self.skipWaiting();
+});
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id');
+
+  if (!clientId || !self.clients) {
+    return;
+  }
+
+  const client = await self.clients.get(clientId);
+
+  if (!client) {
+    return;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  });
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      });
+      break;
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      });
+      break;
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId);
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      });
+      break;
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId);
+      break;
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId);
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId;
+      });
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister();
+      }
+
+      break;
+    }
+  }
+});
+
+addEventListener('fetch', function (event) {
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return;
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (event.request.cache === 'only-if-cached' && event.request.mode !== 'same-origin') {
+    return;
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return;
+  }
+
+  const requestId = crypto.randomUUID();
+  event.respondWith(handleRequest(event, requestId));
+});
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ */
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event);
+  const requestCloneForEvents = event.request.clone();
+  const response = await getResponse(event, client, requestId);
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents);
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone();
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : []
+    );
+  }
+
+  return response;
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId);
+
+  if (activeClientIds.has(event.clientId)) {
+    return client;
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  });
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible';
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id);
+    });
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone();
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers);
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept');
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim());
+      const filteredValues = values.filter((value) => value !== 'msw/passthrough');
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '));
+      } else {
+        headers.delete('accept');
+      }
+    }
+
+    return fetch(requestClone, { headers });
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough();
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough();
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request);
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body]
+  );
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data);
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough();
+    }
+  }
+
+  return passthrough();
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel();
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error);
+      }
+
+      resolve(event.data);
+    };
+
+    client.postMessage(message, [channel.port2, ...transferrables.filter(Boolean)]);
+  });
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error();
+  }
+
+  const mockedResponse = new Response(response.body, response);
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  });
+
+  return mockedResponse;
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  };
+}

--- a/src/services/__tests__/services.test.ts
+++ b/src/services/__tests__/services.test.ts
@@ -1,0 +1,195 @@
+import { services } from '../index';
+
+// Mock fetch globally
+(globalThis as any).fetch = jest.fn();
+
+describe('ArgoCD Services', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('account.canI', () => {
+    it('should return true when user has permission', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: 'yes' }),
+      });
+
+      const result = await services.account.canI('applications', 'sync', 'default/test-app');
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/account/can-i/applications/sync/default/test-app', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(result).toBe(true);
+    });
+
+    it('should return false when user does not have permission', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ value: 'no' }),
+      });
+
+      const result = await services.account.canI('applications', 'sync', 'default/test-app');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when API call fails', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 403,
+        json: async () => ({
+          code: 403,
+          error: 'Forbidden',
+          message: 'You do not have permission to perform this action',
+        }),
+      });
+
+      const result = await services.account.canI('applications', 'sync', 'default/test-app');
+
+      expect(result).toBe(false);
+    });
+
+    it('should return false when fetch throws error', async () => {
+      (fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await services.account.canI('applications', 'sync', 'default/test-app');
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('applications.sync', () => {
+    it('should successfully sync application', async () => {
+      const mockResponse = { metadata: { name: 'test-app' } };
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await services.applications.sync('test-app', 'argocd');
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/applications/test-app/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          appNamespace: 'argocd',
+          dryRun: false,
+          strategy: { hook: { force: false } },
+        }),
+      });
+
+      expect(result.success).toBe(true);
+      expect((result as { data: any }).data).toEqual(mockResponse);
+    });
+
+    it('should sync application with namespace', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      await services.applications.sync('test-app', 'test-namespace');
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/applications/test-app/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          appNamespace: 'test-namespace',
+          dryRun: false,
+          strategy: { hook: { force: false } },
+        }),
+      });
+    });
+
+    it('should sync application in dry-run mode', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      await services.applications.sync('test-app', 'test-namespace', true);
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/applications/test-app/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          appNamespace: 'test-namespace',
+          dryRun: true,
+          strategy: { hook: { force: false } },
+        }),
+      });
+    });
+
+    it('should handle sync failure', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        text: async () => 'Sync failed',
+      });
+
+      const result = await services.applications.sync('test-app', 'argocd');
+
+      expect(result.success).toBe(false);
+      expect((result as { error: string }).error).toContain('Sync failed: 400 Bad Request');
+    });
+
+    it('should handle network errors', async () => {
+      (fetch as jest.Mock).mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await services.applications.sync('test-app', 'argocd');
+
+      expect(result.success).toBe(false);
+      expect((result as { error: string }).error).toContain('Sync error: Network error');
+    });
+  });
+
+  describe('applications.refresh', () => {
+    it('should successfully refresh application', async () => {
+      const mockResponse = { metadata: { name: 'test-app' } };
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const result = await services.applications.refresh('test-app', 'argocd');
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/applications/test-app?refresh=normal&appNamespace=argocd', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+      expect(result.success).toBe(true);
+      expect((result as { data: any }).data).toEqual(mockResponse);
+    });
+
+    it('should refresh application with namespace', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      await services.applications.refresh('test-app', 'test-namespace');
+
+      expect(fetch).toHaveBeenCalledWith('/api/v1/applications/test-app?refresh=normal&appNamespace=test-namespace', {
+        method: 'GET',
+        headers: { 'Content-Type': 'application/json' },
+      });
+    });
+
+    it('should handle refresh failure', async () => {
+      (fetch as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+        text: async () => 'Application not found',
+      });
+
+      const result = await services.applications.refresh('test-app', 'argocd');
+
+      expect(result.success).toBe(false);
+      expect((result as { error: string }).error).toContain('Refresh failed: 404 Not Found');
+    });
+  });
+});

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,134 @@
+/**
+ * Services for ArgoCD API interactions
+ */
+class ArgoCDServices {
+  /**
+   * Account services for permissions
+   */
+  account = {
+    /**
+     * Check if the current user has permission to perform an action
+     * @param resource - The resource type (e.g., 'applications')
+     * @param action - The action to perform (e.g., 'sync', 'get')
+     * @param subresource - The specific resource (e.g., 'project/app-name')
+     * @returns Promise with permission check result
+     */
+    canI: async (resource: string, action: string, subresource: string): Promise<boolean> => {
+      try {
+        const response = await fetch(`/api/v1/account/can-i/${resource}/${action}/${subresource}`, {
+          method: 'GET',
+          headers: {
+            'Content-Type': 'application/json',
+          },
+        });
+
+        if (!response.ok) {
+          console.warn(`Permission check failed: ${response.status} ${response.statusText}`);
+          return false;
+        }
+
+        const result: { value: 'yes' | 'no' } = await response.json();
+        return result.value === 'yes';
+      } catch (error) {
+        console.error('Error checking permissions:', error);
+        return false;
+      }
+    },
+  };
+
+  /**
+   * Application services for actions
+   */
+  applications = {
+    /**
+     * Synchronize an application
+     * @param name - Application name
+     * @param namespace - Application namespace
+     * @param dryRun - Whether to perform a dry run (default: false)
+     * @returns Promise with action result
+     */
+    sync: async (
+      name: string,
+      namespace: string,
+      dryRun: boolean = false
+    ): Promise<{ success: false; error: string } | { success: true; data: any }> => {
+      try {
+        const url = `/api/v1/applications/${name}/sync`;
+
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            appNamespace: namespace,
+            dryRun: dryRun,
+            strategy: { hook: { force: false } },
+          }),
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          return {
+            success: false,
+            error: `Sync failed: ${response.status} ${response.statusText} - ${errorText}`,
+          };
+        }
+
+        const data = await response.json();
+        return {
+          success: true,
+          data,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: `Sync error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        };
+      }
+    },
+
+    /**
+     * Refresh an application
+     * @param name - Application name
+     * @param namespace - Application namespace
+     * @returns Promise with action result
+     */
+    refresh: async (
+      name: string,
+      namespace: string
+    ): Promise<{ success: false; error: string } | { success: true; data: any }> => {
+      try {
+        const url = `/api/v1/applications/${name}`;
+        const params = new URLSearchParams({ refresh: 'normal', appNamespace: namespace });
+
+        const response = await fetch(`${url}?${params}`, {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+        });
+
+        if (!response.ok) {
+          const errorText = await response.text();
+          return {
+            success: false,
+            error: `Refresh failed: ${response.status} ${response.statusText} - ${errorText}`,
+          };
+        }
+
+        const data = await response.json();
+        return {
+          success: true,
+          data,
+        };
+      } catch (error) {
+        return {
+          success: false,
+          error: `Refresh error: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        };
+      }
+    },
+  };
+}
+
+/**
+ * Global services instance
+ */
+export const services = new ArgoCDServices();

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -242,17 +242,7 @@
       color: var(--app-status-#{$status});
     }
   }
-}
 
-// =============================================================================
-// ARGO CD OVERRIDES
-// =============================================================================
-// This section contains style overrides for the official Argo CD
-// 'application-resource-tree' component. These customizations are necessary
-// to integrate the extension's features, such as highlighting unselected nodes.
-// =============================================================================
-
-.application-resource-tree {
   //
   // Node Styles
   //
@@ -260,6 +250,9 @@
   // appearance based on selection state.
   //
   &__node {
+    // Ensure all nodes have relative positioning for quick actions
+    position: relative;
+
     // Default state for all nodes.
     &--default {
       opacity: 1;
@@ -276,6 +269,16 @@
     &--unselected {
       opacity: 0.25;
     }
+
+    &:hover &__node-quick-actions {
+      opacity: 1;
+      visibility: visible;
+      transform: translate(-50%, -50%) scale(1);
+
+      &__button {
+        transition-delay: 0s;
+      }
+    }
   }
 
   //
@@ -284,7 +287,7 @@
   // Customizes the appearance of the resource kind icon (e.g., 'S' for Service).
   //
   &__node-kind-icon {
-    & span.as-icon {
+    &__as-icon {
       background: #8fa4b1;
       border-radius: 50%;
       color: #ffffff;
@@ -297,6 +300,157 @@
       text-align: center;
       vertical-align: middle;
       width: 32px;
+    }
+  }
+
+  //
+  // Node Quick Actions
+  //
+  // Styles for the quick action buttons that appear below the application nodes.
+  // These interactive buttons are aligned to the right with spacing and appear
+  // when hovering over application nodes. They provide quick access to common
+  // operations like sync, delete, etc., and use a card deck animation effect
+  // for a smooth user experience.
+  //
+  &__node-quick-actions {
+    cursor: default;
+    display: flex;
+    flex-direction: row;
+    gap: 4px;
+    left: 0;
+    margin-top: 5px;
+    position: absolute;
+    top: 100%;
+    z-index: -1000;
+
+    //
+    // Quick Action Button
+    //
+    // Individual action buttons with hover effects and state-based styling.
+    // Buttons are initially hidden and animate in with a bouncy transition.
+    //
+    &__button {
+      align-items: center;
+      background: white;
+      border-radius: 4px;
+      box-shadow: rgb(204, 214, 221) 1px 1px 1px 0px;
+      cursor: pointer;
+      display: flex;
+      height: 24px;
+      justify-content: center;
+      opacity: 1;
+      transform: translateY(-30px);
+      transition:
+        opacity 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55),
+        visibility 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55),
+        transform 0.4s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+      transition-delay: 1s;
+      visibility: hidden;
+      width: 24px;
+
+      //
+      // Button Icon
+      //
+      // The icon inside each action button.
+      //
+      i {
+        color: #666;
+        font-size: 14px;
+      }
+
+      //
+      // Hover State
+      //
+      // Applies border colors based on the button's current execution state.
+      //
+      &:hover {
+        z-index: 0;
+
+        &:not(:disabled).idle {
+          border: 2px solid var(--color-primary);
+        }
+
+        &:not(:disabled).executing {
+          border: 2px solid color-mix(in srgb, var(--color-info), black 20%);
+        }
+
+        &:not(:disabled).succeeded {
+          border: 2px solid color-mix(in srgb, var(--color-success), black 20%);
+        }
+
+        &:not(:disabled).failed {
+          border: 2px solid color-mix(in srgb, var(--color-danger), black 20%);
+        }
+      }
+
+      //
+      // Disabled State
+      //
+      // Reduces opacity and disables pointer interaction for disabled buttons.
+      //
+      &:disabled {
+        cursor: default;
+        opacity: 0.3;
+      }
+
+      //
+      // Execution States
+      //
+      // Visual feedback for different action execution states.
+      //
+
+      // Button is currently executing an action.
+      &.executing {
+        background-color: var(--color-info);
+
+        i {
+          animation: spin 1s linear infinite;
+          color: var(--color-white);
+        }
+      }
+
+      // Action completed successfully.
+      &.succeeded {
+        background-color: var(--color-success);
+
+        i {
+          color: var(--color-white);
+        }
+      }
+
+      // Action failed to complete.
+      &.failed {
+        background-color: var(--color-danger);
+
+        i {
+          color: var(--color-white);
+        }
+      }
+
+      //
+      // Animation Timing
+      //
+      // Staggered animation delays for card deck effect.
+      //
+      @for $i from 1 through 2 {
+        .application-resource-tree__node:hover &:nth-child(#{$i}) {
+          transition-delay: 0.2s + $i * 0.1s;
+        }
+      }
+
+      //
+      // Show Animation
+      //
+      // Reveals and animates buttons when parent node is hovered.
+      //
+      .application-resource-tree__node:hover & {
+        transition:
+          opacity 0.3s ease,
+          transform 0.3s ease,
+          visibility 0.1s;
+        transform: translateX(0) rotate(0) scale(1);
+        visibility: visible;
+      }
     }
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export { ConnectionStatus } from './sse';
 export { isApplication, isApplicationSet, HealthStatus, SyncStatus } from './application';
 export { RankDirection } from './rankdirection';
+export { QuickActionState } from './quickActions';
 export type { Application, ApplicationSet } from './application';
 export type { RankDirectionType } from './rankdirection';
 export type { SSEEvent, ConnectionStatusDetails } from './sse';

--- a/src/types/quickActions.ts
+++ b/src/types/quickActions.ts
@@ -1,0 +1,13 @@
+/**
+ * Types for Quick Actions functionality
+ */
+
+/**
+ * Enum representing the possible states of a quick action
+ */
+export enum QuickActionState {
+  Idle = 'Idle',
+  Loading = 'Loading',
+  Success = 'Success',
+  Error = 'Error',
+}


### PR DESCRIPTION
## Add quick actions for application nodes (sync & refresh)

Implements hover-activated quick actions on application nodes that allow users to sync and refresh applications directly from the map view without navigating to individual application pages.

### What this PR does / why we need it

- Adds hover-activated Sync and Refresh buttons to application nodes
- Integrates with ArgoCD API (`/api/v1/applications/{name}/sync` and refresh endpoints)
- Provides real-time visual feedback for action success/failure states
- Handles ArgoCD permissions via `can-i` API with graceful degradation
- Maintains integration with existing SSE real-time update system from PR #125

### Implementation details

- **React components**: New `QuickActions` component with TypeScript types
- **Permission handling**: Real-time RBAC verification before enabling actions
- **Error handling**: Graceful `403 Forbidden` responses with visual feedback
- **Performance**: Optimized rendering with React.memo and proper state management
- **Accessibility**: Hover states maintain clean interface without permanent UI clutter

### Testing

Tested manually and with AI agent using Playwright automation:

- **Functional**: Verified hover interactions, sync/refresh operations, permission handling
- **Performance**: No degradation on maps with 15+ nodes, stable memory usage  
- **Integration**: Compatible with existing SSE system (dark theme not yet implemented)
- **Cross-browser**: Tested on Chrome, Firefox (Safari testing pending)

Closes #116