### PR TITLE
:lock:(react/map-node): Check if the user as all permissions to revert the source drift

### DIFF
--- a/src/components/application-map/node/ApplicationMapNode.tsx
+++ b/src/components/application-map/node/ApplicationMapNode.tsx
@@ -23,10 +23,10 @@ const ApplicationMapNode_Application: React.FC<{
 }> = ({ application, hover }) => {
   const [isSyncAllowed, setIsSyncAllowed] = useState<boolean | null>(null);
   const [isRefreshAllowed, setIsRefreshAllowed] = useState<boolean | null>(null);
+  const [isRevertAllowed, setIsRevertAllowed] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if ((isSyncAllowed !== null && isRefreshAllowed !== null) || !hover) return;
-    console.debug('Checking permissions for application:', application.metadata.name, isRefreshAllowed, isSyncAllowed);
+    if ((isSyncAllowed !== null && isRefreshAllowed !== null && isRevertAllowed !== null) || !hover) return;
 
     if (isSyncAllowed === null)
       services.account
@@ -38,6 +38,11 @@ const ApplicationMapNode_Application: React.FC<{
         .canI('applications', 'get', `${application.metadata.namespace}/${application.metadata.name}`)
         .then(setIsRefreshAllowed)
         .catch(() => setIsRefreshAllowed(false));
+    if (isRevertAllowed === null)
+      services.account
+        .canI('applications', 'update', `${application.metadata.namespace}/${application.metadata.name}`)
+        .then(setIsRevertAllowed)
+        .catch(() => setIsRevertAllowed(false));
   }, [application.metadata.namespace, application.metadata.name, hover]);
 
   return (
@@ -79,7 +84,7 @@ const ApplicationMapNode_Application: React.FC<{
 
         {application.status?.drift === SourceDriftStatus.Drift && (
           <QuickActionButton
-            isUnlocked={true}
+            isUnlocked={isRevertAllowed}
             icon="fa-code-compare"
             title="Revert source drift"
             onClick={async () => {


### PR DESCRIPTION
This pull request updates the `ApplicationMapNode` component to add support for checking and utilizing "revert" permissions for applications. The changes ensure that the "Revert source drift" action is only enabled when the user has the appropriate permissions.

### Enhancements to permission handling:

* [`src/components/application-map/node/ApplicationMapNode.tsx`](diffhunk://#diff-c4e4a4d5a8f85b1a6a933c91519b5d66333e33c3cfc4827016556a7c3a079455R26-R29): Added a new state variable `isRevertAllowed` to track whether the "revert" action is permitted for the application. This state is initialized and updated by calling the `canI` method with the `update` permission for the application. [[1]](diffhunk://#diff-c4e4a4d5a8f85b1a6a933c91519b5d66333e33c3cfc4827016556a7c3a079455R26-R29) [[2]](diffhunk://#diff-c4e4a4d5a8f85b1a6a933c91519b5d66333e33c3cfc4827016556a7c3a079455R41-R45)

* [`src/components/application-map/node/ApplicationMapNode.tsx`](diffhunk://#diff-c4e4a4d5a8f85b1a6a933c91519b5d66333e33c3cfc4827016556a7c3a079455L82-R87): Updated the "Revert source drift" button to use the `isRevertAllowed` state to conditionally enable or disable the action.