### PR TITLE
:lipstick:: Add missing dark theme for quick action buttons

### DIFF
--- a/src/components/application-map/node/QuickActionButton.scss
+++ b/src/components/application-map/node/QuickActionButton.scss
@@ -33,9 +33,10 @@
     //
     &__button {
       align-items: center;
-      background: white;
+      background: var(--background-color);
       border-radius: 4px;
-      box-shadow: rgb(204, 214, 221) 1px 1px 1px 0px;
+      box-shadow: var(--shadow-color) 1px 1px 1px 0px;
+      color: var(--text-color);
       cursor: pointer;
       display: flex;
       height: 24px;
@@ -58,7 +59,6 @@
       // The icon inside each action button.
       //
       i {
-        color: #666;
         font-size: 14px;
       }
 

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -25,6 +25,18 @@
   --color-disabled: #bdbdbd;
 }
 
+.theme-light {
+  --background-color: #ffffff;
+  --shadow-color: #ccd6dd;
+  --text-color: #363c4a;
+}
+
+.theme-dark {
+  --background-color: #303237;
+  --shadow-color: #495763;
+  --text-color: #ffffff;
+}
+
 // =============================================================================
 // GLOBAL UTILITIES
 // =============================================================================


### PR DESCRIPTION
This pull request introduces theme support for light and dark modes by updating styles to use CSS custom properties. The changes include defining theme-specific variables and replacing hardcoded values in the `QuickActionButton` component with these variables.

### Theme support updates:

* [`src/styles/index.scss`](diffhunk://#diff-6d1ac1e7072d002fd68fa47aec09fccdbdd03bfc6b3366e3a7bd5fd96239abf3R28-R39): Added `.theme-light` and `.theme-dark` classes with custom properties for `--background-color`, `--shadow-color`, and `--text-color` to define theme-specific styles.

### Component styling updates:

* [`src/components/application-map/node/QuickActionButton.scss`](diffhunk://#diff-e7e1d7fa7bae199fc1509bb99eedf01c32b0d231ce182734f2efc74941cbaea2L36-R39): Updated the `__button` class to use `--background-color`, `--shadow-color`, and `--text-color` variables instead of hardcoded values for background, shadow, and text colors.
* [`src/components/application-map/node/QuickActionButton.scss`](diffhunk://#diff-e7e1d7fa7bae199fc1509bb99eedf01c32b0d231ce182734f2efc74941cbaea2L61-R62): Updated the `i` element inside the action button to use `--text-color` for its color property.